### PR TITLE
Implement health and scaling system

### DIFF
--- a/HTML Code
+++ b/HTML Code
@@ -83,6 +83,14 @@
             border-radius: 8px;
             z-index: 300; 
         }
+        #healthDisplay {
+            position: absolute;
+            top: 10px;
+            left: 10px;
+            font-size: 18px;
+            font-weight: bold;
+            z-index: 150;
+        }
         @keyframes fadeOutMessage {
             0% { opacity: 1; transform: translateY(0); }
             70% { opacity: 1; transform: translateY(-20px); }
@@ -94,6 +102,7 @@
     <div id="gameContainer">
         <canvas id="gameCanvas"></canvas>
         <div id="loadingMessage" style="display: none;">Loading Assets...</div>
+        <div id="healthDisplay">Health: 1</div>
     </div>
     <div id="instructions">
         <h2>How to Play Sung's Eviction Adventure:</h2>
@@ -105,6 +114,7 @@
         const ctx = canvas.getContext('2d');
         const gameContainer = document.getElementById('gameContainer');
         const loadingMessageElement = document.getElementById('loadingMessage');
+        const healthDisplayElement = document.getElementById("healthDisplay");
 
         const GAME_WIDTH = 800;
         const GAME_HEIGHT = 400;
@@ -130,7 +140,9 @@
 
         let player = {
             x: 50, y: GROUND_LEVEL - 40,
-            width: 30, height: 40, 
+            width: 30, height: 40,
+            baseWidth: 30, baseHeight: 40,
+            health: 1,
             dx: 0, dy: 0, speed: 4, jumpPower: 12,
             isJumping: false, isOnGround: true,
             img: null, isAlive: true
@@ -138,7 +150,8 @@
 
         const TENANT_WIDTH = 30, TENANT_HEIGHT = 30; 
         const JUDGE_WIDTH = 40, JUDGE_HEIGHT = 50;   
-        const GAVEL_WIDTH = 20, GAVEL_HEIGHT = 8; 
+        const GAVEL_WIDTH = 20, GAVEL_HEIGHT = 8;
+        const MAX_HEALTH = 4; 
 
         let enemies = [];
         let platforms = [];
@@ -295,10 +308,13 @@
 
         function initGame() {
             player.img = assets.playerImage;
+            player.health = 1;
+            updatePlayerSize();
             player.x = 50; player.y = GROUND_LEVEL - player.height;
             player.dx = 0; player.dy = 0;
             player.isJumping = false; player.isOnGround = true;
             player.isAlive = true;
+            updateHealthDisplay();
             if (!assets.fireEscapeTexture) {
                 assets.fireEscapeTexture = createFallbackFireEscapePattern();
             }
@@ -370,8 +386,72 @@
         function setGameOver(reason) { player.isAlive = false; gameOver = true; gameOverReason = reason; wisdomFetched = false; let mtc = 'hardship'; if (reason.toLowerCase().includes('evicted') || reason.toLowerCase().includes('jop granted')) mtc = 'evicted'; addGameMessage(reason, player.x, player.y - 30, mtc); }
         function updatePlayer() { if (!player.isAlive) return; if (keys.left) player.dx = -player.speed; else if (keys.right) player.dx = player.speed; else player.dx = 0; player.x += player.dx; if (player.x < 0) player.x = 0; if (player.x + player.width > WORLD_WIDTH) player.x = WORLD_WIDTH - player.width; if (keys.up && player.isOnGround && !player.isJumping) { player.dy = -player.jumpPower; player.isJumping = true; player.isOnGround = false; } player.dy += GRAVITY; player.y += player.dy; player.isOnGround = false; platforms.forEach(platform => { if (player.x < platform.x + platform.width && player.x + player.width > platform.x && player.y < platform.y + platform.height && player.y + player.height > platform.y) { const prevPlayerBottom = player.y + player.height - player.dy; if (player.dy > 0 && prevPlayerBottom <= platform.y) { player.y = platform.y - player.height; player.dy = 0; player.isJumping = false; player.isOnGround = true; } else if (player.dy < 0 && (player.y - player.dy) >= (platform.y + platform.height)) { player.y = platform.y + platform.height; player.dy = 0; } else if (player.dx > 0 && (player.x + player.width - player.dx) <= platform.x) { player.x = platform.x - player.width; } else if (player.dx < 0 && (player.x - player.dx) >= (platform.x + platform.width)) { player.x = platform.x + platform.width; } } }); if (player.y + player.height > GAME_HEIGHT + 100) setGameOver("FELL INTO OBLIVION!"); }
         function updateEnemies() { enemies.forEach(enemy => { if (!enemy.isAlive) return; if (enemy.type === 'tenant') { enemy.x += enemy.dx * enemy.speed; if (enemy.x <= enemy.patrolStart || enemy.x + enemy.width >= enemy.patrolEnd) enemy.dx *= -1; let onPlatform = false; for (let platform of platforms) { if (enemy.x + enemy.width > platform.x && enemy.x < platform.x + platform.width && enemy.y + enemy.height >= platform.y && enemy.y + enemy.height <= platform.y + 10) { enemy.y = platform.y - enemy.height; onPlatform = true; break; } } } else if (enemy.type === 'judge') { enemy.gavelTimer++; if (enemy.gavelTimer >= enemy.gavelCycle) { enemy.gavelTimer = 0; enemy.gavelUp = !enemy.gavelUp; } } }); }
-        function checkCollisions() { if (!player.isAlive) return; enemies.forEach((enemy) => { if (!enemy.isAlive) return; if (player.x < enemy.x + enemy.width && player.x + player.width > enemy.x && player.y < enemy.y + enemy.height && player.y + player.height > enemy.y) { const prevPlayerBottom = player.y + player.height - player.dy; if (player.dy > 0 && prevPlayerBottom <= enemy.y + 5) { if (enemy.type === 'tenant') { enemy.isAlive = false; addGameMessage("EVICTED!", enemy.x, enemy.y - 20, 'evicted'); player.dy = -player.jumpPower / 1.5; } else if (enemy.type === 'judge') { if (!enemy.gavelUp) { enemy.isAlive = false; addGameMessage("JOP GRANTED!", enemy.x, enemy.y - 20, 'jop_granted'); player.dy = -player.jumpPower / 1.5; } else setGameOver("OTSC GRANTED!"); } } else { if (enemy.type === 'tenant') setGameOver("HARDSHIP STAY GRANTED!"); else if (enemy.type === 'judge') setGameOver("OTSC GRANTED!"); } } }); }
+
+function checkCollisions() {
+    if (!player.isAlive) return;
+    enemies.forEach((enemy) => {
+        if (!enemy.isAlive) return;
+        if (player.x < enemy.x + enemy.width &&
+            player.x + player.width > enemy.x &&
+            player.y < enemy.y + enemy.height &&
+            player.y + player.height > enemy.y) {
+            const prevPlayerBottom = player.y + player.height - player.dy;
+            if (player.dy > 0 && prevPlayerBottom <= enemy.y + 5) {
+                if (enemy.type === 'tenant') {
+                    enemy.isAlive = false;
+                    addGameMessage("EVICTED!", enemy.x, enemy.y - 20, 'evicted');
+                    player.dy = -player.jumpPower / 1.5;
+                    gainHealth();
+                } else if (enemy.type === 'judge') {
+                    if (!enemy.gavelUp) {
+                        enemy.isAlive = false;
+                        addGameMessage("JOP GRANTED!", enemy.x, enemy.y - 20, 'jop_granted');
+                        player.dy = -player.jumpPower / 1.5;
+                    } else {
+                        damagePlayer("OTSC GRANTED!", 'otsc_granted');
+                    }
+                }
+            } else {
+                if (enemy.type === 'tenant') {
+                    damagePlayer("HARDSHIP STAY GRANTED!", 'hardship');
+                } else if (enemy.type === 'judge') {
+                    damagePlayer("OTSC GRANTED!", 'otsc_granted');
+                }
+            }
+        }
+    });
+}
         function addGameMessage(text, x, y, typeClass) { const messageElement = document.createElement('div'); messageElement.textContent = text; messageElement.className = `game-message ${typeClass}`; messageElement.style.left = `${x - cameraX}px`; messageElement.style.top = `${y}px`; gameContainer.appendChild(messageElement); setTimeout(() => { if (gameContainer.contains(messageElement)) gameContainer.removeChild(messageElement); }, 2000); }
+        function updatePlayerSize() {
+            const scale = 1 + 0.1 * (player.health - 1);
+            const oldHeight = player.height;
+            player.width = player.baseWidth * scale;
+            player.height = player.baseHeight * scale;
+            player.y -= (player.height - oldHeight);
+        }
+
+        function updateHealthDisplay() {
+            if (healthDisplayElement) healthDisplayElement.textContent = `Health: ${player.health}`;
+        }
+
+        function gainHealth() {
+            if (player.health < MAX_HEALTH) {
+                player.health++;
+                updatePlayerSize();
+                updateHealthDisplay();
+            }
+        }
+
+        function damagePlayer(reason, typeClass) {
+            player.health--;
+            updatePlayerSize();
+            updateHealthDisplay();
+            if (player.health <= 0) {
+                setGameOver(reason);
+            } else {
+                addGameMessage(reason, player.x, player.y - 30, typeClass);
+            }
+        }
         function updateCamera() { cameraX = player.x - GAME_WIDTH / 2 + player.width / 2; if (cameraX < 0) cameraX = 0; if (cameraX > WORLD_WIDTH - GAME_WIDTH) cameraX = WORLD_WIDTH - GAME_WIDTH; }
 
         function drawPlayer() { 


### PR DESCRIPTION
## Summary
- add on-screen health display
- track player health with a maximum of four
- increase player size when gaining health from jumping on a tenant
- decrease health and size when hit by enemies and end the game at zero

## Testing
- `bash -lc 'git status --short'`