### PR TITLE
Add eviction tally and win condition

### DIFF
--- a/HTML Code
+++ b/HTML Code
@@ -71,6 +71,35 @@
         .game_over_message_container .legal-wisdom { font-size: 0.5em; color: #f0f0f0; margin-top: 10px; border-top: 1px solid #ffeb3b; padding-top: 10px; min-height: 30px; }
         .game_over_message_container .legal-wisdom strong { color: #ffcc00; }
 
+        .game_win_message_container {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            font-size: 36px;
+            color: #fff;
+            background-color: rgba(0,128,0,0.85);
+            padding: 20px;
+            border-radius: 10px;
+            text-align: center;
+            z-index: 200;
+            min-width: 300px;
+        }
+        .game_win_message_container .title { font-size: 1em; margin-bottom: 10px; }
+        .game_win_message_container .restart-text { font-size: 0.6em; margin-top: 10px; }
+
+        #evictionTally {
+            position: absolute;
+            bottom: 5px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0,0,0,0.7);
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 14px;
+            z-index: 150;
+        }
+
         #loadingMessage {
             position: absolute;
             top: 50%;
@@ -94,6 +123,7 @@
     <div id="gameContainer">
         <canvas id="gameCanvas"></canvas>
         <div id="loadingMessage" style="display: none;">Loading Assets...</div>
+        <div id="evictionTally">Evictions: 0</div>
     </div>
     <div id="instructions">
         <h2>How to Play Sung's Eviction Adventure:</h2>
@@ -105,6 +135,10 @@
         const ctx = canvas.getContext('2d');
         const gameContainer = document.getElementById('gameContainer');
         const loadingMessageElement = document.getElementById('loadingMessage');
+        const evictionTallyElement = document.getElementById('evictionTally');
+
+        let evictionCount = 0;
+        let gameWon = false;
 
         const GAME_WIDTH = 800;
         const GAME_HEIGHT = 400;
@@ -163,6 +197,29 @@
             if (e.key === 'ArrowRight') keys.right = false;
             if (e.key === 'ArrowUp') keys.up = false;
         });
+
+        function updateEvictionTally() {
+            if (evictionTallyElement) {
+                evictionTallyElement.textContent = `Evictions: ${evictionCount}`;
+            }
+        }
+
+        function setGameWon() {
+            if (gameWon) return;
+            gameWon = true;
+            gameOver = true;
+            player.isAlive = false;
+            let winContainer = gameContainer.querySelector('.game_win_message_container');
+            if (!winContainer) {
+                winContainer = document.createElement('div');
+                winContainer.className = 'game_win_message_container';
+                winContainer.innerHTML = `
+                    <div class="title">Congratulations! All Tenants in Newark Have Been Evicted!</div>
+                    <div class="restart-text">Press 'R' to Restart</div>
+                `;
+                gameContainer.appendChild(winContainer);
+            }
+        }
 
         function createFallbackFireEscapePattern() {
             const pCanvas = document.createElement('canvas');
@@ -304,8 +361,12 @@
             }
             gameOver = false; gameOverReason = ""; wisdomFetched = false; cameraX = 0;
             
-            const existingMessages = gameContainer.querySelectorAll('.game-message, .game_over_message_container');
+            const existingMessages = gameContainer.querySelectorAll('.game-message, .game_over_message_container, .game_win_message_container');
             existingMessages.forEach(msg => msg.remove());
+
+            evictionCount = 0;
+            gameWon = false;
+            updateEvictionTally();
 
             platforms = [ 
                 createPlatform(0, GROUND_LEVEL, WORLD_WIDTH, 50, null) 
@@ -370,7 +431,37 @@
         function setGameOver(reason) { player.isAlive = false; gameOver = true; gameOverReason = reason; wisdomFetched = false; let mtc = 'hardship'; if (reason.toLowerCase().includes('evicted') || reason.toLowerCase().includes('jop granted')) mtc = 'evicted'; addGameMessage(reason, player.x, player.y - 30, mtc); }
         function updatePlayer() { if (!player.isAlive) return; if (keys.left) player.dx = -player.speed; else if (keys.right) player.dx = player.speed; else player.dx = 0; player.x += player.dx; if (player.x < 0) player.x = 0; if (player.x + player.width > WORLD_WIDTH) player.x = WORLD_WIDTH - player.width; if (keys.up && player.isOnGround && !player.isJumping) { player.dy = -player.jumpPower; player.isJumping = true; player.isOnGround = false; } player.dy += GRAVITY; player.y += player.dy; player.isOnGround = false; platforms.forEach(platform => { if (player.x < platform.x + platform.width && player.x + player.width > platform.x && player.y < platform.y + platform.height && player.y + player.height > platform.y) { const prevPlayerBottom = player.y + player.height - player.dy; if (player.dy > 0 && prevPlayerBottom <= platform.y) { player.y = platform.y - player.height; player.dy = 0; player.isJumping = false; player.isOnGround = true; } else if (player.dy < 0 && (player.y - player.dy) >= (platform.y + platform.height)) { player.y = platform.y + platform.height; player.dy = 0; } else if (player.dx > 0 && (player.x + player.width - player.dx) <= platform.x) { player.x = platform.x - player.width; } else if (player.dx < 0 && (player.x - player.dx) >= (platform.x + platform.width)) { player.x = platform.x + platform.width; } } }); if (player.y + player.height > GAME_HEIGHT + 100) setGameOver("FELL INTO OBLIVION!"); }
         function updateEnemies() { enemies.forEach(enemy => { if (!enemy.isAlive) return; if (enemy.type === 'tenant') { enemy.x += enemy.dx * enemy.speed; if (enemy.x <= enemy.patrolStart || enemy.x + enemy.width >= enemy.patrolEnd) enemy.dx *= -1; let onPlatform = false; for (let platform of platforms) { if (enemy.x + enemy.width > platform.x && enemy.x < platform.x + platform.width && enemy.y + enemy.height >= platform.y && enemy.y + enemy.height <= platform.y + 10) { enemy.y = platform.y - enemy.height; onPlatform = true; break; } } } else if (enemy.type === 'judge') { enemy.gavelTimer++; if (enemy.gavelTimer >= enemy.gavelCycle) { enemy.gavelTimer = 0; enemy.gavelUp = !enemy.gavelUp; } } }); }
-        function checkCollisions() { if (!player.isAlive) return; enemies.forEach((enemy) => { if (!enemy.isAlive) return; if (player.x < enemy.x + enemy.width && player.x + player.width > enemy.x && player.y < enemy.y + enemy.height && player.y + player.height > enemy.y) { const prevPlayerBottom = player.y + player.height - player.dy; if (player.dy > 0 && prevPlayerBottom <= enemy.y + 5) { if (enemy.type === 'tenant') { enemy.isAlive = false; addGameMessage("EVICTED!", enemy.x, enemy.y - 20, 'evicted'); player.dy = -player.jumpPower / 1.5; } else if (enemy.type === 'judge') { if (!enemy.gavelUp) { enemy.isAlive = false; addGameMessage("JOP GRANTED!", enemy.x, enemy.y - 20, 'jop_granted'); player.dy = -player.jumpPower / 1.5; } else setGameOver("OTSC GRANTED!"); } } else { if (enemy.type === 'tenant') setGameOver("HARDSHIP STAY GRANTED!"); else if (enemy.type === 'judge') setGameOver("OTSC GRANTED!"); } } }); }
+        function checkCollisions() {
+            if (!player.isAlive) return;
+            enemies.forEach((enemy) => {
+                if (!enemy.isAlive) return;
+                if (player.x < enemy.x + enemy.width &&
+                    player.x + player.width > enemy.x &&
+                    player.y < enemy.y + enemy.height &&
+                    player.y + player.height > enemy.y) {
+                    const prevPlayerBottom = player.y + player.height - player.dy;
+                    if (player.dy > 0 && prevPlayerBottom <= enemy.y + 5) {
+                        if (enemy.type === 'tenant') {
+                            enemy.isAlive = false;
+                            addGameMessage("EVICTED!", enemy.x, enemy.y - 20, 'evicted');
+                            player.dy = -player.jumpPower / 1.5;
+                            evictionCount++;
+                            updateEvictionTally();
+                            if (evictionCount >= 25) setGameWon();
+                        } else if (enemy.type === 'judge') {
+                            if (!enemy.gavelUp) {
+                                enemy.isAlive = false;
+                                addGameMessage("JOP GRANTED!", enemy.x, enemy.y - 20, 'jop_granted');
+                                player.dy = -player.jumpPower / 1.5;
+                            } else setGameOver("OTSC GRANTED!");
+                        }
+                    } else {
+                        if (enemy.type === 'tenant') setGameOver("HARDSHIP STAY GRANTED!");
+                        else if (enemy.type === 'judge') setGameOver("OTSC GRANTED!");
+                    }
+                }
+            });
+        }
         function addGameMessage(text, x, y, typeClass) { const messageElement = document.createElement('div'); messageElement.textContent = text; messageElement.className = `game-message ${typeClass}`; messageElement.style.left = `${x - cameraX}px`; messageElement.style.top = `${y}px`; gameContainer.appendChild(messageElement); setTimeout(() => { if (gameContainer.contains(messageElement)) gameContainer.removeChild(messageElement); }, 2000); }
         function updateCamera() { cameraX = player.x - GAME_WIDTH / 2 + player.width / 2; if (cameraX < 0) cameraX = 0; if (cameraX > WORLD_WIDTH - GAME_WIDTH) cameraX = WORLD_WIDTH - GAME_WIDTH; }
 


### PR DESCRIPTION
## Summary
- track number of evicted tenants
- show tally at bottom of game screen
- add victory screen after 25 evictions

## Testing
- `npm test` *(fails: Could not read package.json)*