### PR TITLE
Remove skyline and resize vehicles

### DIFF
--- a/script.js
+++ b/script.js
@@ -26,7 +26,6 @@
             courthouse: null,
             platformTexture1: null,
             platformTexture2: null,
-            skyline: null,
             background: null
         };
         let assetsToLoad = 0;
@@ -161,7 +160,6 @@
             const judgeGavelUpImageUrl = "https://cdn.glitch.global/011db0f0-56c6-48a7-a8b0-27f2425e6bf7/judge_gavel_up.png?v=1747832367574";   
             const judgeGavelDownImageUrl = "https://cdn.glitch.global/011db0f0-56c6-48a7-a8b0-27f2425e6bf7/judge_gavel_down.png?v=1747832359174";   
             const backgroundUrl = "https://cdn.glitch.global/55dda445-084e-4331-804f-1d4d30d68359/background2.png?v=1747848722965";
-            const skylineImageUrl = "https://cdn.glitch.global/011db0f0-56c6-48a7-a8b0-27f2425e6bf7/skyline.png?v=1747834687120";
             const apartment1Url = "https://cdn.glitch.global/011db0f0-56c6-48a7-a8b0-27f2425e6bf7/apartment5.png?v=1747834222439";
             const apartment2Url = "https://cdn.glitch.global/011db0f0-56c6-48a7-a8b0-27f2425e6bf7/apartment4.png?v=1747834188867";
             const apartment3Url = "https://cdn.glitch.global/011db0f0-56c6-48a7-a8b0-27f2425e6bf7/apartment3.png?v=1747834182727";
@@ -177,7 +175,6 @@
             const judgeGavelUpPlaceholder = `https://placehold.co/${JUDGE_WIDTH}x${JUDGE_HEIGHT}/8A2BE2/FFFFFF?text=J_Up`;   
             const judgeGavelDownPlaceholder = `https://placehold.co/${JUDGE_WIDTH}x${JUDGE_HEIGHT}/6A0DAD/FFFFFF?text=J_Down`;   
             const backgroundPlaceholder = `https://placehold.co/${GAME_WIDTH}x${GAME_HEIGHT}/000000/FFFFFF?text=BG`;
-            const skylinePlaceholder = `https://placehold.co/${GAME_WIDTH}x${GAME_HEIGHT-GROUND_LEVEL}/4A4E69/FFFFFF?text=Skyline`;
             const apartment1Placeholder = `https://placehold.co/150x250/8C7853/FFFFFF?text=Apt1`;
             const apartment2Placeholder = `https://placehold.co/180x220/757575/FFFFFF?text=Apt2`;
             const apartment3Placeholder = `https://placehold.co/160x280/A0522D/FFFFFF?text=Apt3`;
@@ -192,7 +189,6 @@
             loadImage(judgeGavelUpImageUrl, 'judgeGavelUpImage', judgeGavelUpPlaceholder);
             loadImage(judgeGavelDownImageUrl, 'judgeGavelDownImage', judgeGavelDownPlaceholder);
             loadImage(backgroundUrl, 'background', backgroundPlaceholder);
-            loadImage(skylineImageUrl, 'skyline', skylinePlaceholder);
             loadImage(apartment1Url, 'apartment1', apartment1Placeholder);
             loadImage(apartment2Url, 'apartment2', apartment2Placeholder);
             loadImage(apartment3Url, 'apartment3', apartment3Placeholder);
@@ -230,9 +226,15 @@
         }
 
         function adjustVehiclePlatform(p) {
-            p.displayWidth = 128;
-            p.displayHeight = 64;
-            p.width = 128;
+            let scale = 1;
+            if (p.imgKey === 'platformTexture1') {
+                scale = 2; // ambulance
+            } else if (p.imgKey === 'platformTexture2') {
+                scale = 1.5; // police
+            }
+            p.displayWidth = 128 * scale;
+            p.displayHeight = 64 * scale;
+            p.width = 128 * scale;
             p.height = 20;
             p.anchorX = 0.5;
             p.anchorY = 0;
@@ -571,24 +573,6 @@
                 ctx.fillRect(0, 0, GAME_WIDTH, GAME_HEIGHT);
             }
 
-            if (assets.skyline && assets.skyline.complete && assets.skyline.naturalHeight !== 0) {
-                const skylineParallaxFactor = 0.1;
-                const skylineImgWidth = assets.skyline.naturalWidth;
-                const skylineImgHeight = GAME_HEIGHT - GROUND_LEVEL + 50;
-
-                let startX = (-cameraX * skylineParallaxFactor) % skylineImgWidth;
-                // Ensure startX is negative or zero to correctly tile from left
-                if (startX > 0) {
-                    startX -= skylineImgWidth;
-                }
-                
-                for (let i = 0; (startX + i * skylineImgWidth) < GAME_WIDTH; i++) {
-                    ctx.drawImage(assets.skyline, startX + i * skylineImgWidth, 0, skylineImgWidth, skylineImgHeight);
-                }
-            } else { 
-                ctx.fillStyle = '#4a4e69';
-                ctx.fillRect(0, 0, GAME_WIDTH, GAME_HEIGHT - GROUND_LEVEL + 50); 
-            }
 
             backgroundElements.forEach(element => {
                 if (element.img && element.img.complete && element.img.naturalHeight !== 0) {

--- a/style.css
+++ b/style.css
@@ -14,7 +14,7 @@
             border: 2px solid #fff;
             box-shadow: 0 0 15px rgba(255, 255, 255, 0.5);
             position: relative;
-            background-color: #5c5c5c; /* Fallback if skyline doesn't cover everything */
+            background-color: #5c5c5c;
             overflow: hidden;
         }
         canvas {


### PR DESCRIPTION
## Summary
- remove skyline loading and drawing
- enlarge ambulance and police sprites
- clean up comment in stylesheet

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q` *(fails: command not found)*