### PR TITLE
Add death graphic and UI tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
         <div id="evictionTally">Evictions: 0</div>
         <div id="characterSelect" class="overlay">
             <h2>Select Your Character</h2>
-            <div>
-                <button class="character-option" data-char="sung">Sung</button>
+            <div class="character-options">
                 <button class="character-option" data-char="matt">Matt</button>
+                <button class="character-option" data-char="sung">Sung</button>
             </div>
         </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -24,7 +24,8 @@
         const TILE = 32;
         const SPRITE_SCALE = 1;
         const PLAYER_TARGET_HEIGHT = 2 * TILE * SPRITE_SCALE;
-        const TENANT_TARGET_HEIGHT = 2 * TILE * SPRITE_SCALE;
+        // Slightly larger tenants for added challenge
+        const TENANT_TARGET_HEIGHT = 2.5 * TILE * SPRITE_SCALE;
         const JUDGE_TARGET_HEIGHT = 2.5 * TILE * SPRITE_SCALE;
 
 const PROMOTION_THRESHOLDS = [5, 10, 15];
@@ -43,6 +44,9 @@ const PROMOTION_MESSAGES = {
             down10: 'PASTE_DOWN_BELOW_10_URL_HERE',
             down5: 'PASTE_DOWN_BELOW_5_URL_HERE'
         };
+
+        // Placeholder URL for the image shown when the player dies
+        const GAME_OVER_GRAPHIC_URL = 'PASTE_GAME_OVER_GRAPHIC_URL_HERE';
 
         let assets = {
             playerImage: null,
@@ -897,6 +901,7 @@ const GAVEL_HEIGHT = 8 * SPRITE_SCALE;
                     msgContainer.className = 'game_over_message_container';
                     msgContainer.innerHTML = `
                         <div class="title">FIRED!</div>
+                        <img src="${GAME_OVER_GRAPHIC_URL}" alt="Game Over" class="game-over-graphic">
                         <div class="game-over-reason" style="font-size: 0.7em; color: #FF6347; margin-bottom: 10px;">Housing is a human right!</div>
                         <div class="restart-text">Press 'R' to Restart</div>
                     `;

--- a/style.css
+++ b/style.css
@@ -43,6 +43,10 @@
             font-size: 18px;
             cursor: pointer;
         }
+        #characterSelect .character-options {
+            display: flex;
+            flex-direction: row;
+        }
         canvas {
             display: block;
             width: 100%;
@@ -91,6 +95,12 @@
         }
         .game_over_message_container .title { font-size: 1em; margin-bottom: 10px; }
         .game_over_message_container .restart-text { font-size: 0.6em; margin-top: 10px; margin-bottom: 15px; }
+        .game-over-graphic {
+            max-width: 100%;
+            height: auto;
+            display: block;
+            margin: 10px auto;
+        }
 
         #loadingMessage {
             position: absolute;


### PR DESCRIPTION
## Summary
- show buttons horizontally on the character select screen with Matt on the left and Sung on the right
- draw a placeholder image when the game ends and keep restart text below it
- increase tenant sprite size moderately

## Testing
- `npm test` *(fails: Could not read package.json)*